### PR TITLE
Fix typo in message for PHP warnings.

### DIFF
--- a/src/Airbrake/EventHandler.php
+++ b/src/Airbrake/EventHandler.php
@@ -115,7 +115,7 @@ class EventHandler
         }
 
         if ($this->notifyOnWarning && isset ( $this->warningErrors[$type])) {
-            $message = sprintf('A PHP earning occurred (%s). %s', $this->warningErrors[$type], $message);
+            $message = sprintf('A PHP warning occurred (%s). %s', $this->warningErrors[$type], $message);
             $this->airbrakeClient->notifyOnError($message);
             return true;
         }


### PR DESCRIPTION
‘earning’ should be ‘warning’.
