### PR TITLE
Adding the ability to add data to the parameters passed to Airbrake

### DIFF
--- a/src/Airbrake/Configuration.php
+++ b/src/Airbrake/Configuration.php
@@ -81,7 +81,7 @@ class Configuration extends Record
      *
      * @return array
      */
-    public function getParamters()
+    public function getParameters()
     {
         return array_merge($this->get('postData'), $this->get('getData'));
     }

--- a/src/Airbrake/Notice.php
+++ b/src/Airbrake/Notice.php
@@ -73,7 +73,7 @@ class Notice extends Record
         $request->addChild('component', $configuration->get('component'));
         $request->addChild('action', $configuration->get('action'));
 
-        $this->array2Node($request, 'params', array_merge($configuration->getParamters(), array('airbrake_extra' => $this->extraParameters)));
+        $this->array2Node($request, 'params', array_merge($configuration->getParameters(), array('airbrake_extra' => $this->extraParameters)));
         $this->array2Node($request, 'session', $configuration->get('sessionData'));
         $this->array2Node($request, 'cgi-data', $configuration->get('serverData'));
 


### PR DESCRIPTION
Hi,

I only started with Airbrake today so I may be on the wrong track with this, but in our project we are sending emails from a queue and want to report when they fail to send.

We need to be able to see the email sent and the error returned so we can diagnose and fix, but I didn't see any way to put this data into the call to Airbrake without modifying the library. I've added the ability to supply extraParameters when you call $notice->load() and have them get to Airbrake in their own airbrake_extras parameter.

If I'm on the wrong track let me know and I can correct.

Cheers,
Ben
