### PR TITLE
Adding more information to exception messages

### DIFF
--- a/src/Airbrake/Client.php
+++ b/src/Airbrake/Client.php
@@ -77,7 +77,7 @@ class Client
         $notice->load(array(
             'errorClass'   => get_class($exception),
             'backtrace'    => $this->cleanBacktrace($exception->getTrace() ?: debug_backtrace()),
-            'errorMessage' => $exception->getMessage(),
+            'errorMessage' => $exception->getMessage().' in '.$exception->getFile().' on line '.$exception->getLine(),
         ));
 
         return $this->notify($notice);


### PR DESCRIPTION
I'm using your project with CodebaseHQ which supports Airbrake style exception logging.  This is so the log show the line number and file where the exception occurred.
