### PR TITLE
Move warnings from fatalErrors array to warningErrors

### DIFF
--- a/src/Airbrake/EventHandler.php
+++ b/src/Airbrake/EventHandler.php
@@ -23,22 +23,22 @@ class EventHandler
     protected $airbrakeClient = null;
     protected $notifyOnWarning = null;
 
-    protected $warningErrors = array ( \E_NOTICE          => 'Notice',
-                                       \E_STRICT          => 'Strict',
-                                       \E_USER_WARNING    => 'User Warning',
-                                       \E_USER_NOTICE     => 'User Notice',
-                                       \E_DEPRECATED      => 'Deprecated',
-                                       \E_USER_DEPRECATED => 'User Deprecated',
-                                       \E_CORE_WARNING    => 'Core Warning' );
+    protected $warningErrors = array ( \E_NOTICE            => 'Notice',
+                                       \E_STRICT            => 'Strict',
+                                       \E_USER_WARNING      => 'User Warning',
+                                       \E_USER_NOTICE       => 'User Notice',
+                                       \E_DEPRECATED        => 'Deprecated',
+                                       \E_WARNING           => 'Warning',
+                                       \E_USER_DEPRECATED   => 'User Deprecated',
+                                       \E_CORE_WARNING      => 'Core Warning',
+                                       \E_COMPILE_WARNING   => 'Compile Warning',
+                                       \E_RECOVERABLE_ERROR => 'Recoverable Error' );
 
     protected $fatalErrors = array ( \E_ERROR             => 'Error',
                                      \E_PARSE             => 'Parse',
-                                     \E_COMPILE_WARNING   => 'Compile Warning',
                                      \E_COMPILE_ERROR     => 'Compile Error',
                                      \E_CORE_ERROR        => 'Core Error',
-                                     \E_WARNING           => 'Warning',
-                                     \E_USER_ERROR        => 'User Error',
-                                     \E_RECOVERABLE_ERROR => 'Recoverable Error' );
+                                     \E_USER_ERROR        => 'User Error' );
     
     /**
      * Build with the Airbrake client class.


### PR DESCRIPTION
I'm not sure if there is a justification i'm missing here, but a PHP warning was being classed as a fatal error and throwing an exception, rather than just logging the warning. This changes that behaviour so warnings are treated as warnings.

Either way, this was throwing an exception which was breaking our code.
