### PR TITLE
Warnings are no longer reported if not configured to during PHP shutdown...

### DIFF
--- a/src/Airbrake/EventHandler.php
+++ b/src/Airbrake/EventHandler.php
@@ -162,6 +162,11 @@ class EventHandler
             return;
         }
 
+        // Don't notify on warning if not configured to.
+        if (!$this->notifyOnWarning && isset($this->warningErrors[$error['type']])) {
+            return;
+        }
+
         $message = 'It looks like we may have shutdown unexpectedly. Here is the error '
                  . 'we saw while closing up: %s  File: %s  Line: %d';
 


### PR DESCRIPTION
Hey Drew,

I noticed in `EventHandler` that the `onShutdown` method didn't take into account whether warnings should be reported. I've modified that method to take into account `$this->notifyOnWarning` now. Thanks!

Justin
