### PR TITLE
Escaping special characters in the error message

### DIFF
--- a/src/Airbrake/Notice.php
+++ b/src/Airbrake/Notice.php
@@ -56,7 +56,7 @@ class Notice extends Record
 
         $error = $doc->addChild('error');
         $error->addChild('class', $this->errorClass);
-        $error->addChild('message', $this->errorMessage);
+        $error->addChild('message', htmlspecialchars($this->errorMessage));
 
         if (count($this->backtrace) > 0) {
             $backtrace = $error->addChild('backtrace');


### PR DESCRIPTION
I was getting an error that looked like this with an exception contains SQL output in it:

```
SimpleXMLElement::addChild() [<a href='simplexmlelement.addchild'>simplexmlelement.addchild</a>]: unterminated entity reference &amp; visible = 1 &amp;&amp; tagged_contentforeign_type NOT IN ('daily_term', 'inspiration')
```

I figure this patch will help others who may have things in their errors that XML doesn't like.
