### PR TITLE
HTTPS (SSL) support for apiEndPoint

### DIFF
--- a/src/Airbrake/Connection.php
+++ b/src/Airbrake/Connection.php
@@ -57,6 +57,8 @@ class Connection
 		curl_setopt($curl, CURLOPT_POSTFIELDS, $xml);
 		curl_setopt($curl, CURLOPT_HTTPHEADER, $this->headers);
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+		curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);
 
         $return = curl_exec($curl);
 		curl_close($curl);


### PR DESCRIPTION
We have ssl apiendpoint url, which is not supported by current version of php-airbrake
