### PR TITLE
Preventing errors if there is no $_SERVER['SCRIPT_NAME']

### DIFF
--- a/src/Airbrake/Configuration.php
+++ b/src/Airbrake/Configuration.php
@@ -71,8 +71,11 @@ class Configuration extends Record
         }
 
         if (!$this->url) {
-            if (isset($this->serverData['REDIRECT_URL'])) $this->url = $this->serverData['REDIRECT_URL'];
-            elseif (isset($this->serverData['SCRIPT_NAME'])) $this->url = $this->serverData['SCRIPT_NAME'];
+            if (isset($this->serverData['REDIRECT_URL'])) {
+                $this->url = $this->serverData['REDIRECT_URL'];
+            } elseif (isset($this->serverData['SCRIPT_NAME'])) {
+                $this->url = $this->serverData['SCRIPT_NAME'];
+            }
         }
 
         if (!$this->hostname) {


### PR DESCRIPTION
On some environments, when running through CLI, I've encountered cases where there is no 'SCRIPT_NAME' global set.
