### PR TITLE
Some missing XML options + passing extraParams

### DIFF
--- a/src/Airbrake/Client.php
+++ b/src/Airbrake/Client.php
@@ -63,9 +63,10 @@ class Client
      *
      * @param string $message
      * @param array $backtrace
+     * @param null $extraParams
      * @return string
      */
-    public function notifyOnError($message, array $backtrace = null)
+    public function notifyOnError($message, array $backtrace = null, $extraParams = null)
     {
         if (!$backtrace) {
             $backtrace = debug_backtrace();
@@ -79,6 +80,7 @@ class Client
             'errorClass'   => 'PHP Error',
             'backtrace'    => $backtrace,
             'errorMessage' => $message,
+            'extraParams'  => $extraParams,
         ));
 
         return $this->notify($notice);
@@ -88,15 +90,17 @@ class Client
      * Notify on an exception
      *
      * @param Exception $exception
+     * @param null $extraParams
      * @return string
      */
-    public function notifyOnException(Exception $exception)
+    public function notifyOnException(Exception $exception, $extraParams = null)
     {
         $notice = new Notice;
         $notice->load(array(
             'errorClass'   => get_class($exception),
             'backtrace'    => $this->cleanBacktrace($exception->getTrace() ?: debug_backtrace()),
             'errorMessage' => $exception->getMessage().' in '.$exception->getFile().' on line '.$exception->getLine(),
+            'extraParams'  => $extraParams,
         ));
 
         return $this->notify($notice);

--- a/src/Airbrake/Configuration.php
+++ b/src/Airbrake/Configuration.php
@@ -35,7 +35,7 @@ class Configuration extends Record
         'resource' => '/notifier_api/v2/notices',
         'apiEndPoint' => null,
         'errorReportingLevel' => null,
-        'extraParams' => null,
+        'extraParameters' => null,
     );
 
     /** @var array */

--- a/src/Airbrake/Configuration.php
+++ b/src/Airbrake/Configuration.php
@@ -29,11 +29,13 @@ class Configuration extends Record
         'projectRoot' => null,
         'url' => null,
         'hostname' => null,
+        'appVersion' => null,
         'secure' => false,
         'host' => 'api.airbrake.io',
         'resource' => '/notifier_api/v2/notices',
         'apiEndPoint' => null,
         'errorReportingLevel' => null,
+        'extraParams' => null,
     );
 
     /** @var array */

--- a/src/Airbrake/Notice.php
+++ b/src/Airbrake/Notice.php
@@ -68,7 +68,15 @@ class Notice extends Record
         $request->addChild('action', $configuration->get('action'));
 
         $extras = $this->get('extraParameters');
-        $innerExtras = array_merge($configuration->get('extraParameters'), $extras);
+        $configExtras = $configuration->get('extraParameters');
+
+        if (!isset($extras))
+            $extras = array();
+        if (!isset($configExtras))
+            $configExtras = array();
+
+        $innerExtras = array_merge($extras, $configExtras);
+
         $params = array_merge($configuration->getParameters(), array('airbrake_extra' => $innerExtras));
 
         $this->array2Node($request, 'params', $params);
@@ -99,7 +107,7 @@ class Notice extends Record
 
             // htmlspecialchars() is needed to prevent html characters from breaking the node.
             $node->addChild('var', htmlspecialchars($value))
-                 ->addAttribute('key', $key);
+                ->addAttribute('key', $key);
         }
     }
 }

--- a/src/Airbrake/Notice.php
+++ b/src/Airbrake/Notice.php
@@ -70,10 +70,12 @@ class Notice extends Record
         $extras = $this->get('extraParameters');
         $configExtras = $configuration->get('extraParameters');
 
-        if (!isset($extras))
+        if (!isset($extras)) {
             $extras = array();
-        if (!isset($configExtras))
+        }
+        if (!isset($configExtras)) {
             $configExtras = array();
+        }
 
         $innerExtras = array_merge($extras, $configExtras);
 

--- a/src/Airbrake/Notice.php
+++ b/src/Airbrake/Notice.php
@@ -41,6 +41,8 @@ class Notice extends Record
         $env = $doc->addChild('server-environment');
         $env->addChild('project-root', $configuration->get('projectRoot'));
         $env->addChild('environment-name', $configuration->get('environmentName'));
+        $env->addChild('hostname', $configuration->get('hostname'));
+        $env->addChild('app_version', $configuration->get('appVersion'));
 
         $error = $doc->addChild('error');
         $error->addChild('class', $this->get('errorClass'));
@@ -66,7 +68,8 @@ class Notice extends Record
         $request->addChild('action', $configuration->get('action'));
 
         $extras = $this->get('extraParameters');
-        $params = array_merge($configuration->getParameters(), array('airbrake_extra' => $extras));
+        $innerExtras = array_merge($configuration->get('extraParameters'), $extras);
+        $params = array_merge($configuration->getParameters(), array('airbrake_extra' => $innerExtras));
 
         $this->array2Node($request, 'params', $params);
         $this->array2Node($request, 'session', $configuration->get('sessionData'));


### PR DESCRIPTION
1. App version and hostname were missing from XML - they were automatically assumed, but in the case of multiple versions and multiple machines for the library user - it's good to be able to set these for the XML.
2. Allowed to set extraParameters from the configuration
3. Allowed to pass extraParams from the notices