### PR TITLE
User our standard format so we can better group

### DIFF
--- a/src/Airbrake/Client.php
+++ b/src/Airbrake/Client.php
@@ -77,7 +77,7 @@ class Client
 
         $notice = new Notice;
         $notice->load(array(
-            'errorClass'   => 'PHP Error',
+            'errorClass'   => 'PHP::Error',
             'backtrace'    => $backtrace,
             'errorMessage' => $message,
             'extraParams'  => $extraParams,


### PR DESCRIPTION
We ( Airbrake ) don't like to use spaces for our Distinct error types. Since the PHP notifier hard codes this in it means we throw all errors into one bucket. By changing this to our  standard format it'll be much better for our customers to easily put these errors as _Distinct Error Classes_ See https://help.airbrake.io/kb/customizations/distinct-error-classes 

## Before, No luck putting it into distinct group.

![image](https://cloud.githubusercontent.com/assets/559288/7212108/65feb300-e517-11e4-876b-b99c14f5b80f.png)

## After, Happy Days :-) 
![image](https://cloud.githubusercontent.com/assets/559288/7212141/c65889b0-e517-11e4-8a4c-ddc08843f84c.png)
