### PR TITLE
Added HTTP proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Configuration Options
 - **hostname** - The hostname that was requested.
 - **secure** - Optional - Boolean that allows you to define if you want to hit the secure Airbrake endpoint.
 - **errorReportingLevel** - Optional - functions the same way as the error_reporting php.ini setting (this is applied on top of show warnings parameter on the EventHandler::start method)
+- **proxyHost** - An optional HTTP proxy host through which all connections will be sent.
+- **proxyPort** - The HTTP proxy port (required only if proxyHost is supplied). Defaults to 80.
+- **proxyUser** - The HTTP proxy username (optional even if proxyHost is supplied).
+- **proxyPass** - The HTTP proxy password (required only if proxyUser is supplied).
 
 Filters
 =======

--- a/src/Airbrake/Configuration.php
+++ b/src/Airbrake/Configuration.php
@@ -36,6 +36,10 @@ class Configuration extends Record
         'apiEndPoint' => null,
         'errorReportingLevel' => null,
         'extraParameters' => null,
+        'proxyHost' => null,
+        'proxyPort' => 80,
+        'proxyUser' => null,
+        'proxyPass' => null
     );
 
     /** @var array */

--- a/src/Airbrake/Connection.php
+++ b/src/Airbrake/Connection.php
@@ -59,6 +59,17 @@ class Connection implements Connection\ConnectionInterface
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);
 
+        // HTTP proxy support
+        $proxyHost = $this->configuration->get('proxyHost');
+        $proxyUser = $this->configuration->get('proxyUser');
+
+        if (null !== $proxyHost) {
+            curl_setopt($curl, CURLOPT_PROXY, $proxyHost.':'.$this->configuration->get('proxyPort'));
+            if (null !== $proxyUser) {
+                curl_setopt($curl, CURLOPT_PROXYUSERPWD, $proxyUser.':'.$this->configuration->get('proxyPass'));
+            }
+        }
+
         $return = curl_exec($curl);
         curl_close($curl);
 


### PR DESCRIPTION
Some of our environments require all external connections to go through a proxy. These changes add basic HTTP proxy support (with optional user/pass) for the connections to Airbrake.