### PR TITLE
Require php cURL extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     }],
 
     "require-dev": {
-        "php":             ">=5.3.3",
+        "php": ">=5.3.3",
+        "ext-curl": "*",
         "phpunit/phpunit": "*",
         "squizlabs/php_codesniffer": "*"
     },


### PR DESCRIPTION
Composer allows you to require certain extensions.  This library uses the cURL extension and this was not specified in the composer file.  The result of installing on a server without cURL was no exception reporting either on Airbrake or in the application.